### PR TITLE
Fix fatal error when BuddyPress is deactivated or not available

### DIFF
--- a/lib/plugin-hooks.php
+++ b/lib/plugin-hooks.php
@@ -204,7 +204,7 @@ add_filter( 'bbp_get_user_subscribe_link', 'openlab_style_bbp_subscribe_link', 1
  * bbPress maps everything onto Participant. We don't want to have to use that.
  */
 function openlab_bbp_map_group_forum_meta_caps( $caps = array(), $cap = '', $user_id = 0, $args = array() ) {
-	if ( ! bp_is_group() ) {
+	if ( ! function_exists( 'bp_is_group' ) || ! bp_is_group() ) {
 		return $caps;
 	}
 	switch ( $cap ) {


### PR DESCRIPTION
Hi @boonebgorges,

Came across this fatal error while deactivating BuddyPress when the OpenLab theme is currently active.

Just did a simple `function_exists()` check to fix the problem.