### PR TITLE
Fix fatal error when accessing the WP Edit Post interface and when BP Docs is active

### DIFF
--- a/lib/plugin-hooks.php
+++ b/lib/plugin-hooks.php
@@ -34,7 +34,10 @@ if ( defined( 'BP_GROUP_DOCUMENTS_VERSION' ) ) {
 	require_once( get_template_directory() . '/lib/plugin-mods/files-funcs.php' );
 }
 
-if ( defined( 'BP_DOCS_VERSION' ) ) {
+/**
+ * BuddyPress Docs - Only load on the frontend.
+ */
+if ( defined( 'BP_DOCS_VERSION' ) && ! defined( 'WP_NETWORK_ADMIN' ) ) {
 	require_once( get_template_directory() . '/lib/plugin-mods/docs-funcs.php' );
 }
 


### PR DESCRIPTION
Hi @boonebgorges,

I'm on a bug spree it seems.  Came across another one:
```
PHP Fatal error:  Call to undefined function bp_docs_is_doc_edit() in \wp-content\themes\openlab-theme\lib\plugin-mods\docs-funcs.php on line 13
```

This occurs if BuddyPress Docs is active and when editing any post in the WP admin dashboard.  When I looked at the `docs-funcs.php` file, it appears all the mods there are only applicable to the frontend.  So this PR only loads up `docs-funcs.php` if we're not in the admin area.

I haven't actually tested if this breaks things for BP Docs integration yet, but I think it shouldn't.