### PR TITLE
Use correct 'falsy' value in group members query string

### DIFF
--- a/buddypress/groups/single/admin.php
+++ b/buddypress/groups/single/admin.php
@@ -353,7 +353,7 @@ openlab_group_admin_js_data( $group_type );
 			<div class="bp-widget">
 				<h4><?php _e( 'Members', 'openlab-theme' ); ?></h4>
 
-				<?php if ( bp_group_has_members( 'per_page=15&exclude_banned=false' ) ) : ?>
+				<?php if ( bp_group_has_members( 'per_page=15&exclude_banned=0' ) ) : ?>
 
 					<?php if ( bp_group_member_needs_pagination() ) : ?>
 


### PR DESCRIPTION
Partial fix for https://github.com/cuny-academic-commons/commons-in-a-box/issues/202