### PR TITLE
Fix messages pagination

### DIFF
--- a/lib/member-funcs.php
+++ b/lib/member-funcs.php
@@ -537,13 +537,10 @@ add_action( 'bp_before_member_body', 'openlab_member_header' );
 function openlab_messages_pagination() {
 	global $messages_template;
 
-	$page_arg = '%#%';
-
 	if ( (int) $messages_template->total_thread_count && (int) $messages_template->pag_num ) {
 		$pagination = paginate_links(
 			array(
 				'base'      => add_query_arg(
-					$page_arg,
 					array(
 						'mpage' => '%#%',
 					)


### PR DESCRIPTION
Fixes messages pagination as reported here:
https://cboxopenlab.org/groups/help-forum/forum/topic/users-cannot-access-any-page-of-paginated-ol-messages-except-the-first-page/