### PR TITLE
Redirect to Portfolios page if not on a valid group directory type

### DIFF
--- a/buddypress/groups/index-directory.php
+++ b/buddypress/groups/index-directory.php
@@ -1,14 +1,13 @@
 <?php
 $current_type = bp_get_current_group_directory_type();
+$type_object  = cboxol_get_group_type( $current_type );
 
-// Redirect to Portfolios if we're not on a valid directory type.
-if ( empty( $current_type ) ) {
-	bp_core_redirect( bp_get_group_type_directory_permalink( 'portfolio' ) );
+// Redirect to the home page if we're not on a valid group directory page.
+if ( is_wp_error( $type_object ) ) {
+	bp_core_redirect( bp_get_root_domain() );
 }
 
 get_header();
-
-$type_object  = cboxol_get_group_type( $current_type );
 
 $can_create = is_user_logged_in() && bp_user_can_create_groups();
 if ( $type_object->get_is_course() ) {

--- a/buddypress/groups/index-directory.php
+++ b/buddypress/groups/index-directory.php
@@ -1,7 +1,13 @@
 <?php
+$current_type = bp_get_current_group_directory_type();
+
+// Redirect to Portfolios if we're not on a valid directory type.
+if ( empty( $current_type ) ) {
+	bp_core_redirect( bp_get_group_type_directory_permalink( 'portfolio' ) );
+}
+
 get_header();
 
-$current_type = bp_get_current_group_directory_type();
 $type_object  = cboxol_get_group_type( $current_type );
 
 $can_create = is_user_logged_in() && bp_user_can_create_groups();


### PR DESCRIPTION
If you navigate to `/groups/`, a fatal error will be shown:

![Screenshot](https://cboxopenlab.org/?get_group_doc=2/1654206252-screenshot-openlab.bmcc.cuny.edu-2022.06.02-15_49_31.png)

Reported here: https://cboxopenlab.org/groups/help-forum/forum/topic/test-facultys-portfolio-home-goes-nowhere-is-no-longer-linked/

The problem is due to:

https://github.com/cuny-academic-commons/openlab-theme/blob/55628697a917f70b52dbb5b698086026d37a43e1/buddypress/groups/index-directory.php#L8

When you navigate to `/groups/`, `$type_object` is a `WP_Error` object.

This PR redirects invalid group types to the Portfolios Directory page. I wasn't sure if we wanted to redirect or show a message. I also wasn't sure if we wanted to redirect to another group type directory like `'course'`.

Feel free to do something different altogether though!