### PR TITLE
Fix group feature toggle reset on "Groups" admin dashboard page

### DIFF
--- a/lib/plugin-hooks.php
+++ b/lib/plugin-hooks.php
@@ -330,6 +330,11 @@ add_action( 'bp_ass_send_activity_notification_for_user', 'openlab_forums_activi
  * Handle feature toggling for groups.
  */
 function openlab_group_feature_toggle( $group_id ) {
+	// Bail if in admin as these toggles are only available on the frontend.
+	if ( is_admin() ) {
+		return;
+	}
+
 	// phpcs:disable WordPress.Security.NonceVerification.Missing
 	// Discussion.
 	$enable_forum        = ! empty( $_POST['openlab-edit-group-forum'] );


### PR DESCRIPTION
See https://github.com/cuny-academic-commons/commons-in-a-box/issues/408 for details.