### PR TITLE
No error message when composing an empty private message

### DIFF
--- a/buddypress/members/single/messages.php
+++ b/buddypress/members/single/messages.php
@@ -1,5 +1,8 @@
 <?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 <?php echo openlab_submenu_markup( 'messages' ); ?>
+
+<?php do_action( 'template_notices' ); ?>
+
 <?php if ( 'compose' === bp_current_action() ) : ?>
 	<?php bp_get_template_part( 'members/single/messages/compose' ); ?>
 


### PR DESCRIPTION
Reported here: https://cboxopenlab.org/groups/help-forum/forum/topic/bug-ol-messages-with-empty-subject-are-not-sent/.

Problem is due to a missing `'template_notices'` hook for the `messages.php` template.