### PR TITLE
Move individual registration fields into their own template parts

### DIFF
--- a/buddypress/members/register-parts/email.php
+++ b/buddypress/members/register-parts/email.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Email field for the signup form.
+ *
+ * @since 1.7.0
+ */
+
+$limited_email_domains_message = '';
+$limited_email_domains         = get_site_option( 'limited_email_domains' );
+if ( $limited_email_domains ) {
+	$led = array();
+	foreach ( $limited_email_domains as $d ) {
+		$led[] = sprintf( '<span class="limited-email-domain">' . esc_html( $d ) . '</span>' );
+	}
+	$limited_email_domains_message = sprintf(
+		// translators: list of allowed email domains
+		esc_html__( 'Allowed email domains: %s', 'commons-in-a-box' ),
+		implode( ', ', $led )
+	);
+}
+
+?>
+
+<div class="form-group">
+	<label class="control-label" for="signup_email"><?php esc_html_e( 'Email Address (required)', 'commons-in-a-box' ); ?> <?php
+	if ( $limited_email_domains_message ) :
+		?>
+		<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<div class="email-requirements"><?php echo $limited_email_domains_message; ?></div><?php endif; ?></label>
+	<?php do_action( 'bp_signup_email_errors' ); ?>
+	<input
+		class="form-control"
+		type="text"
+		name="signup_email"
+		id="signup_email"
+		value="<?php echo esc_attr( openlab_post_value( 'signup_email' ) ); ?>"
+		data-parsley-trigger="blur"
+		data-parsley-required
+		data-parsley-type="email"
+		data-parsley-group="email"
+		data-parsley-iff="#signup_email_confirm"
+		data-parsley-iff-message=""
+	/>
+
+	<label class="control-label" for="signup_email_confirm"><?php esc_html_e( 'Confirm Email Address (required)', 'commons-in-a-box' ); ?></label>
+	<input
+	class="form-control"
+	type="text"
+	name="signup_email_confirm"
+	id="signup_email_confirm"
+	value="<?php echo esc_attr( openlab_post_value( 'signup_email_confirm' ) ); ?>"
+	data-parsley-trigger="blur"
+	data-parsley-required
+	data-parsley-type="email"
+	data-parsley-iff="#signup_email"
+	data-parsley-iff-message="<?php esc_attr_e( 'Email addresses must match.', 'commons-in-a-box' ); ?>"
+	data-parsley-group="email"
+	/>
+</div>

--- a/buddypress/members/register-parts/password.php
+++ b/buddypress/members/register-parts/password.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Password field for the signup form.
+ *
+ * @since 1.7.0
+ */
+?>
+
+<div data-parsley-children-should-match class="form-group">
+	<label class="control-label" for="signup_password"><?php esc_html_e( 'Choose a Password', 'commons-in-a-box' ); ?> <?php esc_html_e( '(required)', 'commons-in-a-box' ); ?></label>
+	<?php do_action( 'bp_signup_password_errors' ); ?>
+	<div class="password-field">
+		<input
+			class="form-control"
+			type="password"
+			name="signup_password"
+			id="signup_password"
+			value=""
+			data-parsley-trigger="blur"
+			data-parsley-required
+			data-parsley-group="password"
+			data-parsley-iff="#signup_password_confirm"
+			data-parsley-iff-message=""
+		/>
+
+		<div id="password-strength-notice" class="password-strength-notice"></div>
+	</div>
+
+	<label class="control-label" for="signup_password_confirm"><?php esc_html_e( 'Confirm Password', 'commons-in-a-box' ); ?> <?php esc_html_e( '(required)', 'commons-in-a-box' ); ?></label>
+	<?php do_action( 'bp_signup_password_confirm_errors' ); ?>
+	<input
+		class="form-control password-field"
+		type="password"
+		name="signup_password_confirm"
+		id="signup_password_confirm"
+		value=""
+		data-parsley-trigger="blur"
+		data-parsley-required
+		data-parsley-group="password"
+		data-parsley-iff="#signup_password"
+		data-parsley-iff-message="<?php esc_attr_e( 'Passwords must match.', 'commons-in-a-box' ); ?>"
+	/>
+</div>
+

--- a/buddypress/members/register-parts/username.php
+++ b/buddypress/members/register-parts/username.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Username field for the signup form.
+ *
+ * @since 1.7.0
+ */
+?>
+
+<div class="form-group">
+	<label class="control-label" for="signup_username"><?php esc_html_e( 'Username', 'commons-in-a-box' ); ?> <?php esc_html_e( '(required)', 'commons-in-a-box' ); ?> <?php esc_html_e( '(lowercase & no special characters)', 'commons-in-a-box' ); ?></label>
+	<?php do_action( 'bp_signup_username_errors' ); ?>
+	<?php
+	$login_check_url = add_query_arg(
+		array(
+			'action' => 'openlab_unique_login_check',
+			'login'  => '{value}',
+		),
+		bp_core_ajax_url()
+	);
+	?>
+	<input
+		class="form-control"
+		type="text"
+		name="signup_username"
+		id="signup_username"
+		value="<?php esc_attr( bp_signup_username_value() ); ?>"
+		data-parsley-lowercase
+		data-parsley-nospecialchars
+		data-parsley-required
+		data-parsley-minlength="4"
+		data-parsley-remote="<?php echo esc_attr( $login_check_url ); ?>"
+		data-parsley-remote-message="<?php esc_attr_e( 'That username is already taken.', 'commons-in-a-box' ); ?>"
+	/>
+</div>

--- a/buddypress/members/register.php
+++ b/buddypress/members/register.php
@@ -10,22 +10,7 @@
 
 	$registration_form_settings = cboxol_get_registration_form_settings();
 
-	$ajaxurl   = bp_core_ajax_url();
 	$site_name = bp_get_option( 'blogname' );
-
-	$limited_email_domains_message = '';
-	$limited_email_domains         = get_site_option( 'limited_email_domains' );
-	if ( $limited_email_domains ) {
-		$led = array();
-		foreach ( $limited_email_domains as $d ) {
-			$led[] = sprintf( '<span class="limited-email-domain">' . esc_html( $d ) . '</span>' );
-		}
-		$limited_email_domains_message = sprintf(
-			// translators: list of allowed email domains
-			esc_html__( 'Allowed email domains: %s', 'commons-in-a-box' ),
-			implode( ', ', $led )
-		);
-	}
 
 	$member_types = cboxol_get_member_types();
 
@@ -56,105 +41,9 @@
 
 						<div class="register-section" id="basic-details-section">
 
-							<div class="form-group">
-								<label class="control-label" for="signup_username"><?php esc_html_e( 'Username', 'commons-in-a-box' ); ?> <?php esc_html_e( '(required)', 'commons-in-a-box' ); ?> <?php esc_html_e( '(lowercase & no special characters)', 'commons-in-a-box' ); ?></label>
-								<?php do_action( 'bp_signup_username_errors' ); ?>
-								<?php
-								$login_check_url = add_query_arg(
-									array(
-										'action' => 'openlab_unique_login_check',
-										'login'  => '{value}',
-									),
-									$ajaxurl
-								);
-								?>
-								<input
-									class="form-control"
-									type="text"
-									name="signup_username"
-									id="signup_username"
-									value="<?php esc_attr( bp_signup_username_value() ); ?>"
-									data-parsley-lowercase
-									data-parsley-nospecialchars
-									data-parsley-required
-									data-parsley-minlength="4"
-									data-parsley-remote="<?php echo esc_attr( $login_check_url ); ?>"
-									data-parsley-remote-message="<?php esc_attr_e( 'That username is already taken.', 'commons-in-a-box' ); ?>"
-								/>
-							</div>
-
-							<div class="form-group">
-								<label class="control-label" for="signup_email"><?php esc_html_e( 'Email Address (required)', 'commons-in-a-box' ); ?> <?php
-								if ( $limited_email_domains_message ) :
-									?>
-									<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-									<div class="email-requirements"><?php echo $limited_email_domains_message; ?></div><?php endif; ?></label>
-								<?php do_action( 'bp_signup_email_errors' ); ?>
-								<input
-									class="form-control"
-									type="text"
-									name="signup_email"
-									id="signup_email"
-									value="<?php echo esc_attr( openlab_post_value( 'signup_email' ) ); ?>"
-									data-parsley-trigger="blur"
-									data-parsley-required
-									data-parsley-type="email"
-									data-parsley-group="email"
-									data-parsley-iff="#signup_email_confirm"
-									data-parsley-iff-message=""
-								/>
-
-								<label class="control-label" for="signup_email_confirm"><?php esc_html_e( 'Confirm Email Address (required)', 'commons-in-a-box' ); ?></label>
-								<input
-								class="form-control"
-								type="text"
-								name="signup_email_confirm"
-								id="signup_email_confirm"
-								value="<?php echo esc_attr( openlab_post_value( 'signup_email_confirm' ) ); ?>"
-								data-parsley-trigger="blur"
-								data-parsley-required
-								data-parsley-type="email"
-								data-parsley-iff="#signup_email"
-								data-parsley-iff-message="<?php esc_attr_e( 'Email addresses must match.', 'commons-in-a-box' ); ?>"
-								data-parsley-group="email"
-								/>
-							</div>
-
-							<div data-parsley-children-should-match class="form-group">
-								<label class="control-label" for="signup_password"><?php esc_html_e( 'Choose a Password', 'commons-in-a-box' ); ?> <?php esc_html_e( '(required)', 'commons-in-a-box' ); ?></label>
-								<?php do_action( 'bp_signup_password_errors' ); ?>
-								<div class="password-field">
-									<input
-										class="form-control"
-										type="password"
-										name="signup_password"
-										id="signup_password"
-										value=""
-										data-parsley-trigger="blur"
-										data-parsley-required
-										data-parsley-group="password"
-										data-parsley-iff="#signup_password_confirm"
-										data-parsley-iff-message=""
-									/>
-
-									<div id="password-strength-notice" class="password-strength-notice"></div>
-								</div>
-
-								<label class="control-label" for="signup_password_confirm"><?php esc_html_e( 'Confirm Password', 'commons-in-a-box' ); ?> <?php esc_html_e( '(required)', 'commons-in-a-box' ); ?></label>
-								<?php do_action( 'bp_signup_password_confirm_errors' ); ?>
-								<input
-									class="form-control password-field"
-									type="password"
-									name="signup_password_confirm"
-									id="signup_password_confirm"
-									value=""
-									data-parsley-trigger="blur"
-									data-parsley-required
-									data-parsley-group="password"
-									data-parsley-iff="#signup_password"
-									data-parsley-iff-message="<?php esc_attr_e( 'Passwords must match.', 'commons-in-a-box' ); ?>"
-								/>
-							</div>
+							<?php bp_get_template_part( 'members/register-parts/username' ); ?>
+							<?php bp_get_template_part( 'members/register-parts/email' ); ?>
+							<?php bp_get_template_part( 'members/register-parts/password' ); ?>
 
 						</div><!-- #basic-details-section -->
 					</div>

--- a/buddypress/members/register.php
+++ b/buddypress/members/register.php
@@ -1,6 +1,6 @@
-<?php /**
- *  sign up form template
- *
+<?php
+/**
+ * Member registration template.
  */
 ?>
 


### PR DESCRIPTION
Registration workflows related to SSO may have different requirements or desired functionality when it comes to certain registration fields that appear on an out-of-the-box CBOX-OL registration page. It's likely that all SSO integration will want to remove the 'password' fields. Some may wish to hide the email fields and replace them with, say, a hidden field containing the email address from the IdP. Some may wish to customize the way the `username` field works.

In the sps-cbox-sso tool that @jeremyfelt wrote, he accomplishes some of this by overriding the entire `register.php` template. In this case, his only change to the template was to remove the 'password' fields. This is a big hammer for a small nail: Overriding templates makes it difficult to customize in a child theme, and it causes problems if there are upstream fixes to templates. 

It would be nice if there was another way to provide the necessary flexibility here. I toyed with a couple ideas involving filters. For example, you could have a boolean filter `cboxol_require_registration_email_field`. But this is not enough: in some cases, you may to customize the field, or put something else in its place (like a hidden field). So you'd need a second `do_action()` hook. This all seems cumbersome.

In the current pull request, I went with a different strategy: Each of the WP-required fields - `username`, `email`, and `password` - have been moved into their own template parts, and loaded with `bp_get_template_part()`. This creates a new level of template depth, but I think it's a worthwhile tradeoff for the flexibility. Before committing to it for 1.7.0, I was hoping to get feedback from @r-a-y and/or @jeremyfelt on the approach.

cc @beckej13820